### PR TITLE
Added a fix to the instantiated item on hover

### DIFF
--- a/Lvl99GameJam/Assets/Prefabs/DummyObject.prefab
+++ b/Lvl99GameJam/Assets/Prefabs/DummyObject.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4423469583823103472
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4423469583823103484}
+  - component: {fileID: 4423469583823103487}
+  m_Layer: 0
+  m_Name: DummyObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4423469583823103484
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4423469583823103472}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4423469583823103487
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4423469583823103472}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Lvl99GameJam/Assets/Prefabs/DummyObject.prefab.meta
+++ b/Lvl99GameJam/Assets/Prefabs/DummyObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e028af37600ed8f4c83359e19aaea7f3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lvl99GameJam/Assets/Prefabs/GridSpace.prefab
+++ b/Lvl99GameJam/Assets/Prefabs/GridSpace.prefab
@@ -94,3 +94,4 @@ MonoBehaviour:
   clickedSprite: {fileID: 21300000, guid: ab3a31658ff26e24eb5e200f830ee7b7, type: 3}
   elevatorPrefab: {fileID: 4423469583823103472, guid: c69b4fd9fb632ee438de7dbb416a72fe, type: 3}
   fanPrefab: {fileID: 8523397510590346052, guid: 5a5744afcb951824791b190e39e8b8d4, type: 3}
+  dummyObject: {fileID: 4423469583823103472, guid: e028af37600ed8f4c83359e19aaea7f3, type: 3}

--- a/Lvl99GameJam/Assets/Scripts/Fan.cs
+++ b/Lvl99GameJam/Assets/Scripts/Fan.cs
@@ -18,7 +18,6 @@ public class Fan : MonoBehaviour
         {
             rb = hit.collider.GetComponent<Rigidbody2D>();
             rb.AddForce(transform.right * forcePower, ForceMode2D.Force);
-            Debug.Log("Player in LOS of fan");
         }
 
         Debug.DrawRay(transform.position, transform.right * Mathf.Infinity, Color.white);


### PR DESCRIPTION
Item instantiated when hovering over a grid space no longer collides with the player and does not execute its logic until it is placed.